### PR TITLE
feat(mcp): add dataset visualization creation tool

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -58,6 +58,7 @@ Dataset Management:
 - list_datasets: List datasets with advanced filters (1-based pagination)
 - get_dataset_info: Get detailed dataset information by ID
 - get_dataset_available_filters: List available dataset filter fields/operators
+- create_charts_and_dashboard_from_dataset: Generate charts and dashboards from a dataset
 
 Chart Management:
 - list_charts: List charts with advanced filters (1-based pagination)
@@ -291,6 +292,7 @@ from superset.mcp_service.dashboard.tool import (  # noqa: F401, E402
     list_dashboards,
 )
 from superset.mcp_service.dataset.tool import (  # noqa: F401, E402
+    create_charts_and_dashboard_from_dataset,
     get_dataset_available_filters,
     get_dataset_info,
     list_datasets,

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -33,8 +33,14 @@ from pydantic import (
     PositiveInt,
 )
 
+from superset.mcp_service.chart.schemas import (
+    ChartConfig,
+    GenerateChartResponse,
+    QueryCacheControl,
+)
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
 from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.dashboard.schemas import DashboardInfo
 from superset.mcp_service.system.schemas import (
     PaginationInfo,
     TagInfo,
@@ -198,6 +204,82 @@ class DatasetList(BaseModel):
     total_pages: int
     has_previous: bool
     has_next: bool
+
+
+class DatasetChartSpec(BaseModel):
+    """Chart specification for dataset-driven chart creation."""
+
+    config: ChartConfig = Field(..., description="Chart configuration to generate")
+    preview_formats: List[
+        Literal["url", "interactive", "ascii", "vega_lite", "table", "base64"]
+    ] | None = Field(
+        None,
+        description="Optional preview formats for this chart (overrides global setting)",
+    )
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class CreateDatasetVisualizationsRequest(QueryCacheControl):
+    """Request schema for creating charts and an optional dashboard from a dataset."""
+
+    dataset_id: int | str = Field(..., description="Dataset identifier (ID or UUID)")
+    charts: List[DatasetChartSpec] = Field(
+        ..., min_length=1, description="Charts to generate from the dataset"
+    )
+    save_charts: bool = Field(
+        default=True,
+        description="Whether to persist created charts in Superset",
+    )
+    generate_previews: bool = Field(
+        default=True,
+        description="Whether to generate previews for created charts",
+    )
+    preview_formats: List[
+        Literal["url", "interactive", "ascii", "vega_lite", "table", "base64"]
+    ] = Field(
+        default_factory=lambda: ["url"],
+        description="Preview formats to request when generating charts",
+    )
+    create_dashboard: bool = Field(
+        default=True,
+        description="Whether to assemble the created charts into a dashboard",
+    )
+    dashboard_title: str | None = Field(
+        None,
+        description="Optional title for the generated dashboard",
+        max_length=255,
+    )
+    dashboard_description: str | None = Field(
+        None,
+        description="Optional description for the generated dashboard",
+    )
+    publish_dashboard: bool = Field(
+        default=True,
+        description="Whether to publish the generated dashboard",
+    )
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class CreateDatasetVisualizationsResponse(BaseModel):
+    """Response schema for dataset-driven chart and dashboard creation."""
+
+    charts: List[GenerateChartResponse] = Field(
+        default_factory=list, description="Chart creation responses"
+    )
+    dashboard: DashboardInfo | None = Field(
+        None, description="Created dashboard details when requested"
+    )
+    dashboard_url: str | None = Field(
+        None, description="URL to view the generated dashboard"
+    )
+    success: bool = Field(
+        default=False, description="Overall success status for the operation"
+    )
+    message: str | None = Field(None, description="Summary of the operation result")
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
     columns_requested: List[str] | None = None
     columns_loaded: List[str] | None = None
     filters_applied: List[DatasetFilter] = Field(

--- a/superset/mcp_service/dataset/tool/__init__.py
+++ b/superset/mcp_service/dataset/tool/__init__.py
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .create_charts_and_dashboard import create_charts_and_dashboard_from_dataset
 from .get_dataset_available_filters import get_dataset_available_filters
 from .get_dataset_info import get_dataset_info
 from .list_datasets import list_datasets
 
 __all__ = [
+    "create_charts_and_dashboard_from_dataset",
     "list_datasets",
     "get_dataset_info",
     "get_dataset_available_filters",

--- a/superset/mcp_service/dataset/tool/create_charts_and_dashboard.py
+++ b/superset/mcp_service/dataset/tool/create_charts_and_dashboard.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# under the License.
+"""Dataset-driven chart and dashboard generation MCP tool."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastmcp import Context
+from superset_core.mcp import tool
+
+from superset.mcp_service.chart.schemas import GenerateChartRequest, GenerateChartResponse
+from superset.mcp_service.chart.tool.generate_chart import generate_chart
+from superset.mcp_service.dashboard.schemas import (
+    GenerateDashboardRequest,
+    GenerateDashboardResponse,
+)
+from superset.mcp_service.dashboard.tool.generate_dashboard import generate_dashboard
+from superset.mcp_service.dataset.schemas import (
+    CreateDatasetVisualizationsRequest,
+    CreateDatasetVisualizationsResponse,
+)
+from superset.mcp_service.utils.schema_utils import parse_request
+
+
+def _build_chart_requests(
+    request: CreateDatasetVisualizationsRequest,
+) -> List[GenerateChartRequest]:
+    """Construct per-chart requests from the dataset-level request."""
+
+    chart_requests: List[GenerateChartRequest] = []
+    for chart_spec in request.charts:
+        preview_formats = chart_spec.preview_formats or request.preview_formats
+        chart_requests.append(
+            GenerateChartRequest(
+                dataset_id=request.dataset_id,
+                config=chart_spec.config,
+                save_chart=request.save_charts,
+                generate_preview=request.generate_previews,
+                preview_formats=preview_formats,
+                cache_timeout=request.cache_timeout,
+                force=request.force,
+            )
+        )
+
+    return chart_requests
+
+
+def _build_dashboard_request(
+    request: CreateDatasetVisualizationsRequest, chart_ids: List[int]
+) -> GenerateDashboardRequest:
+    """Create a dashboard generation request using created chart IDs."""
+
+    title = request.dashboard_title or f"Dashboard for dataset {request.dataset_id}"
+    return GenerateDashboardRequest(
+        chart_ids=chart_ids,
+        dashboard_title=title,
+        description=request.dashboard_description,
+        published=request.publish_dashboard,
+    )
+
+
+@tool(tags=["mutate"])
+@parse_request(CreateDatasetVisualizationsRequest)
+async def create_charts_and_dashboard_from_dataset(
+    request: CreateDatasetVisualizationsRequest, ctx: Context
+) -> CreateDatasetVisualizationsResponse:
+    """Create charts from a dataset and optionally assemble them into a dashboard."""
+
+    await ctx.info(
+        "Starting dataset visualization pipeline: dataset_id=%s, charts=%s",
+        request.dataset_id,
+        len(request.charts),
+    )
+
+    chart_requests = _build_chart_requests(request)
+    chart_responses: List[GenerateChartResponse] = []
+
+    for index, chart_request in enumerate(chart_requests, start=1):
+        await ctx.report_progress(index, len(chart_requests), "Generating chart")
+        chart_response = await generate_chart(chart_request, ctx)
+        chart_responses.append(chart_response)
+
+    successful_chart_ids = [
+        chart_response.chart.id
+        for chart_response in chart_responses
+        if chart_response.success and chart_response.chart
+    ]
+
+    dashboard_response: GenerateDashboardResponse | None = None
+    if request.create_dashboard:
+        if successful_chart_ids:
+            dashboard_request = _build_dashboard_request(request, successful_chart_ids)
+            await ctx.report_progress(
+                len(chart_requests) + 1,
+                len(chart_requests) + 1,
+                "Creating dashboard",
+            )
+            dashboard_response = generate_dashboard(dashboard_request, ctx)
+        else:
+            dashboard_response = GenerateDashboardResponse(
+                dashboard=None,
+                dashboard_url=None,
+                error="No charts were created successfully; dashboard was not generated.",
+            )
+
+    success = all(response.success for response in chart_responses)
+    if request.create_dashboard:
+        success = success and bool(
+            dashboard_response and dashboard_response.dashboard is not None
+        )
+
+    message = "Created charts successfully"
+    if request.create_dashboard:
+        message = (
+            "Created charts and dashboard successfully"
+            if success
+            else "Charts created, but dashboard generation failed"
+        )
+        if dashboard_response and dashboard_response.error:
+            message = dashboard_response.error
+
+    return CreateDatasetVisualizationsResponse(
+        charts=chart_responses,
+        dashboard=dashboard_response.dashboard if dashboard_response else None,
+        dashboard_url=dashboard_response.dashboard_url if dashboard_response else None,
+        success=success,
+        message=message,
+    )


### PR DESCRIPTION
### SUMMARY
- add an MCP tool that builds charts from a dataset and assembles them into a dashboard when requested
- introduce dataset-level request/response schemas to drive the new visualization workflow
- register the tool and advertise it in the default MCP instructions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- N/A (backend change)

### TESTING INSTRUCTIONS
- Not run (not requested)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69379aa447dc832689e6a0afd54fed24)